### PR TITLE
Use env python

### DIFF
--- a/chomyk.py
+++ b/chomyk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import sys


### PR DESCRIPTION
Code as written uses python from a specific location `/usr/bin/python`

It's more common practice to use `python` interpreter from the user's env (`/usr/bin/env python`)

This is more portable because some python is likely to be on the user's path. /usr/bin/python is less portable.